### PR TITLE
Add automatic item reload and bump version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.devvoxel</groupId>
     <artifactId>ItemDB</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ItemDB</name>

--- a/src/main/java/net/devvoxel/itemDB/ItemDB.java
+++ b/src/main/java/net/devvoxel/itemDB/ItemDB.java
@@ -10,6 +10,7 @@ import org.bstats.charts.SingleLineChart;
 import org.bstats.charts.SimplePie;
 import org.bukkit.Bukkit;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 public class ItemDB extends JavaPlugin {
 
@@ -19,6 +20,7 @@ public class ItemDB extends JavaPlugin {
     private ItemManager itemManager;
     private MessageManager messageManager;
     private ItemsGui itemsGui;
+    private BukkitTask reloadTask;
 
     public static ItemDB get() {
         return instance;
@@ -60,6 +62,13 @@ public class ItemDB extends JavaPlugin {
                     getConfig().getString("Database.Type", "mysql").toLowerCase())
             );
 
+            this.reloadTask = Bukkit.getScheduler().runTaskTimerAsynchronously(
+                    this,
+                    () -> itemManager.load(false),
+                    20L,
+                    20L
+            );
+
             getLogger().info("ItemDB erfolgreich aktiviert.");
             getLogger().info("Geladene Items aus Datenbank: " + itemManager.size());
         } catch (Exception e) {
@@ -70,6 +79,10 @@ public class ItemDB extends JavaPlugin {
 
     @Override
     public void onDisable() {
+        if (reloadTask != null) {
+            reloadTask.cancel();
+            reloadTask = null;
+        }
         if (database != null) {
             database.close();
         }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: ItemDB
-version: '1.0.1-SNAPSHOT'
+version: '1.0.2-SNAPSHOT'
 main: net.devvoxel.itemDB.ItemDB
 api-version: '1.21'
 authors: [ DevVoxel ]


### PR DESCRIPTION
## Summary
- schedule an asynchronous task that reloads items from the database every second so caches stay fresh across servers
- make the item cache thread-safe and allow silent reload logging when used by the scheduler
- bump the plugin metadata to version 1.0.2-SNAPSHOT

## Testing
- mvn -q -DskipTests package *(fails: Maven Central returned 403 when downloading maven-resources-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68f00b5031f4832e81c2b754713875cf