### PR TITLE
Fix compilation errors in command and item manager

### DIFF
--- a/src/main/java/net/devvoxel/itemDB/command/DbCommand.java
+++ b/src/main/java/net/devvoxel/itemDB/command/DbCommand.java
@@ -139,8 +139,7 @@ public class DbCommand implements CommandExecutor, TabCompleter {
             String action = args[2].toLowerCase(Locale.ROOT);
 
             switch (action) {
-                case "display":
-                case "displayname" -> {
+                case "display", "displayname" -> {
                     if (args.length == 3) {
                         if (plugin.items().clearDisplayName(name)) {
                             sender.sendMessage(msg.get("item-display-cleared").replace("{name}", name));
@@ -232,11 +231,14 @@ public class DbCommand implements CommandExecutor, TabCompleter {
                         }
                         return true;
                     }
+                    sender.sendMessage(msg.get("usage-edit-custommodel"));
+                    return true;
+                }
+                default -> {
+                    sender.sendMessage(msg.get("usage-edit"));
+                    return true;
                 }
             }
-
-            sender.sendMessage(msg.get("usage-edit"));
-            return true;
         }
 
         // /db add <name>

--- a/src/main/java/net/devvoxel/itemDB/managers/ItemManager.java
+++ b/src/main/java/net/devvoxel/itemDB/managers/ItemManager.java
@@ -198,8 +198,8 @@ public class ItemManager {
         Map<String, Integer> enchantments = meta != null && !meta.getEnchants().isEmpty()
                 ? meta.getEnchants().entrySet().stream()
                 .collect(java.util.stream.Collectors.toMap(e -> {
-                    var key = e.getKey().getKey();
-                    return key.getNamespace() + ":" + key.getKey();
+                    var namespacedKey = e.getKey().getKey();
+                    return namespacedKey.getNamespace() + ":" + namespacedKey.getKey();
                 }, Map.Entry::getValue))
                 : Map.of();
 


### PR DESCRIPTION
## Summary
- avoid shadowing the buildRecord method parameter when serialising enchantments
- refactor the /db edit action switch to use a consistent enhanced switch and preserve usage messaging

## Testing
- mvn -q -DskipTests package *(fails: unable to download maven-resources-plugin due to 403 from repo.maven.apache.org)*

------
https://chatgpt.com/codex/tasks/task_e_68f015cf7af4832ea3d6ab9901514271